### PR TITLE
README.md 라이센스 링크 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ khaiii의 빌드 및 설치에 관해서는 [빌드 및 설치 문서](doc/setup
 
 License
 ----
-This software is licensed under the [Apache 2 license](LICENSE.txt), quoted below.
+This software is licensed under the [Apache 2 license](LICENSE), quoted below.
 
 Copyright 2018 Kakao Corp. <http://www.kakaocorp.com>
 


### PR DESCRIPTION
Apache 2 license 링크 클릭시 
`https://github.com/kakao/khaiii/blob/master/LICENSE.txt`로 이동하는 것을 
`https://github.com/kakao/khaiii/blob/master/LICENSE`로 이동하도록 수정하였습니다.