### PR TITLE
Make log level default to warn on CLI and Python bindings. #12.

### DIFF
--- a/src/main/cpp/main.cpp
+++ b/src/main/cpp/main.cpp
@@ -81,9 +81,7 @@ int run(const cxxopts::ParseResult& opts) {
 //////////
 int main(int argc, char** argv) {
     auto _log = spdlog::stderr_color_mt("console");
-#ifdef NDEBUG
     spdlog::set_level(spdlog::level::warn);
-#endif
 
     cxxopts::Options options("khaiii", "analyze with khaiii");
     options.add_options()

--- a/src/main/python/khaiii/khaiii.py
+++ b/src/main/python/khaiii/khaiii.py
@@ -170,6 +170,7 @@ class KhaiiiApi:
         logging.debug('khaiii library path: %s', lib_path)
         self._lib = ctypes.CDLL(lib_path)
         self._set_arg_res_types()
+        self.set_log_level('all', 'warn')
 
     def __del__(self):
         self.close()


### PR DESCRIPTION
There is a nicer way of doing this, but the expected size of the incision needed for that to happen is probably larger than what can be justified for a minor change like this. For those reasons, patch is done in two places.