### PR TITLE
특정 환경에서 오류가 발생하는 경우가 있으므로 빌드 시 멀티 프로세스 옵션 "-j"를 제거 #23

### DIFF
--- a/src/main/python/setup.py.in
+++ b/src/main/python/setup.py.in
@@ -47,7 +47,7 @@ class CustomBuild(build):
         build_dir = f'{_SRC_NAME}/build'
         os.makedirs(build_dir, exist_ok=True)
         subprocess.check_call('cmake ..', cwd=build_dir, shell=True)
-        subprocess.check_call('make -j all resource', cwd=build_dir, shell=True)
+        subprocess.check_call('make all resource', cwd=build_dir, shell=True)
         shutil.rmtree('khaiii/lib', ignore_errors=True)
         shutil.copytree(f'{build_dir}/lib', 'khaiii/lib')
         shutil.rmtree('khaiii/share', ignore_errors=True)


### PR DESCRIPTION
설명 (Description)
----
* 빌드 시간을 빠르게 하기 위해 setup.py 안에 "make" 명령어에 "-j" 옵션을 넣었는데, 이로 인해 특정 환경에서는 빌드 오류가 발생하는 경우도 있습니다. 안전하게 가기위해 옵션을 제거합니다.


개발자를 위한 가이드 (Developer's Guide)
----
만약 khaiii에 pull request가 처음이라면 [개발자를 위한 가이드](https://github.com/kakao/khaiii/wiki#%EA%B0%9C%EB%B0%9C%EC%9E%90%EB%A5%BC-%EC%9C%84%ED%95%9C-%EA%B0%80%EC%9D%B4%EB%93%9C) 문서들을 한번 읽어보시길 권고드립니다.

If this is your first pull request for khaiii, please see the [Developer's Guide](https://github.com/kakao/khaiii/wiki#%EA%B0%9C%EB%B0%9C%EC%9E%90%EB%A5%BC-%EC%9C%84%ED%95%9C-%EA%B0%80%EC%9D%B4%EB%93%9C).


체크 리스트 (Checklist)
----
pull request 전에 아래 체크 리스트들을 만족하는 지 확인한 후 체크('x') 표시를 해주시기 바랍니다.

Before you submit pull requests, please check(set 'x') to the checklist below.

- [x] master 브랜치가 아니라 **develop** 브랜치에 머지하도록 pull request를 작성 중이신가요? (Did you merge into **develop** branch not master?)
- [x] `build/test/khaiii` 프로그램을 실행하여 **테스트**가 성공했나요? (Did all **tests** are passed when you ran as `build/test/khaiii`)
- [x] **PyLint** 툴을 실행하여 발생한 에러를 모두 수정하셨나요? (Did you fix all errors after running **PyLint**?)
- [x] **CppLint** 툴을 실행하여 발생한 에러를 모두 수정하셨나요? (Did you fix all errors after running **CppLint**?)
