### PR TITLE
Add exception for option

### DIFF
--- a/src/main/cpp/khaiii/Config.cpp
+++ b/src/main/cpp/khaiii/Config.cpp
@@ -62,9 +62,14 @@ Config* Config::copy_and_override(const char* opt_str) {
     if (found != _cfg_cache.end()) return found->second.get();
 
     auto cfg = copy();
-    auto jsn = nlohmann::json::parse(opt_str);
-    cfg->override_members(jsn);
-    _cfg_cache[opt_str] = cfg;
+    try {
+        auto jsn = nlohmann::json::parse(opt_str);
+        cfg->override_members(jsn);
+        _cfg_cache[opt_str] = cfg;
+    } catch (const exception& exc) {
+        throw Except(fmt::format("fail to parse option: {}\n{}", exc.what(), opt_str));
+    }
+
     return cfg.get();
 }
 


### PR DESCRIPTION
설명 (Description)
----
`Config.cpp`에 빠진 Exception을 추가합니다.

Python에서 API 호출을 아래와 같이 
옵션 자리에 잘못된 값을 넣어서 호출하면, 
(리스트가 들어갈 수 있을 것으로 판단해서 리스트를 넣어버리는 경우)
Python Interpreter가 바로 죽어버리는 현상을 막기위함입니다.
(Jupyter에서 잘못 이용한 경우 Kernel이 죽어버리기도 합니다.)
```python
import khaiii
api = khaiii.KhaiiiApi()
api.open()

for word in api.analyze('안녕, 세상.', '원래는 옵션자리'):
    morphs_str = ' + '.join([(m.lex + '/' + m.tag) for m in word.morphs])
    print(f'{word.lex}\t{morphs_str}')
```



체크 리스트 (Checklist)
----
pull request 전에 아래 체크 리스트들을 만족하는 지 확인한 후 체크('x') 표시를 해주시기 바랍니다.

Before you submit pull requests, please check(set 'x') to the checklist below.

- [x] master 브랜치가 아니라 **develop** 브랜치에 머지하도록 pull request를 작성 중이신가요? (Did you merge into **develop** branch not master?)
- [x] `build/test/khaiii` 프로그램을 실행하여 **테스트**가 성공했나요? (Did all **tests** are passed when you ran as `build/test/khaiii`)
- [x] **PyLint** 툴을 실행하여 발생한 에러를 모두 수정하셨나요? (Did you fix all errors after running **PyLint**?)
- [x] **CppLint** 툴을 실행하여 발생한 에러를 모두 수정하셨나요? (Did you fix all errors after running **CppLint**?)
