### PR TITLE
f-strings로 인해 python 3.6 버전 이하에서 오류가 나는 부분 수정 #59

### DIFF
--- a/src/main/python/setup.py.in
+++ b/src/main/python/setup.py.in
@@ -42,16 +42,16 @@ class CustomBuild(build):
         """
         run build command
         """
-        with zipfile.ZipFile(f'{_SRC_NAME}.zip', 'r') as src_zip:
+        with zipfile.ZipFile('{}.zip'.format(_SRC_NAME), 'r') as src_zip:
             src_zip.extractall()
-        build_dir = f'{_SRC_NAME}/build'
+        build_dir = '{}/build'.format(_SRC_NAME)
         os.makedirs(build_dir, exist_ok=True)
         subprocess.check_call('cmake ..', cwd=build_dir, shell=True)
         subprocess.check_call('make all resource', cwd=build_dir, shell=True)
         shutil.rmtree('khaiii/lib', ignore_errors=True)
-        shutil.copytree(f'{build_dir}/lib', 'khaiii/lib')
+        shutil.copytree('{}/lib'.format(build_dir), 'khaiii/lib')
         shutil.rmtree('khaiii/share', ignore_errors=True)
-        shutil.copytree(f'{build_dir}/share', 'khaiii/share')
+        shutil.copytree('{}/share'.format(build_dir), 'khaiii/share')
         shutil.rmtree(_SRC_NAME)
         build.run(self)
 
@@ -83,13 +83,12 @@ setup(
         'Development Status :: 5 - Stable',
         'License :: OSI Approved :: Apache 2.0',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
     ],
     license='Apache 2.0',
     packages=['khaiii', ],
     include_package_data=True,
     install_requires=[],
-    setup_requires=['cmake>=3.10', 'pytest-runner'],
+    setup_requires=['pytest-runner', ],
     tests_require=['pytest', ],
     zip_safe=False,
     cmdclass={'build': CustomBuild}


### PR DESCRIPTION
설명 (Description)
----
* setup.py에서 실치 시 f-strings 문법을 사용해 python 3.6보다 낮은 버전에서 설치가 되지 않는 문제를 해결했습니다.

개발자를 위한 가이드 (Developer's Guide)
----
만약 khaiii에 pull request가 처음이라면 [개발자를 위한 가이드](https://github.com/kakao/khaiii/wiki#%EA%B0%9C%EB%B0%9C%EC%9E%90%EB%A5%BC-%EC%9C%84%ED%95%9C-%EA%B0%80%EC%9D%B4%EB%93%9C) 문서들을 한번 읽어보시길 권고드립니다.

If this is your first pull request for khaiii, please see the [Developer's Guide](https://github.com/kakao/khaiii/wiki#%EA%B0%9C%EB%B0%9C%EC%9E%90%EB%A5%BC-%EC%9C%84%ED%95%9C-%EA%B0%80%EC%9D%B4%EB%93%9C).


체크 리스트 (Checklist)
----
pull request 전에 아래 체크 리스트들을 만족하는 지 확인한 후 체크('x') 표시를 해주시기 바랍니다.

Before you submit pull requests, please check(set 'x') to the checklist below.

- [x] master 브랜치가 아니라 **develop** 브랜치에 머지하도록 pull request를 작성 중이신가요? (Did you merge into **develop** branch not master?)
- [x] `build/test/khaiii` 프로그램을 실행하여 **테스트**가 성공했나요? (Did all **tests** are passed when you ran as `build/test/khaiii`)
- [x] **PyLint** 툴을 실행하여 발생한 에러를 모두 수정하셨나요? (Did you fix all errors after running **PyLint**?)
- [x] **CppLint** 툴을 실행하여 발생한 에러를 모두 수정하셨나요? (Did you fix all errors after running **CppLint**?)
