### PR TITLE
Fix C++17 compatibility.

### DIFF
--- a/src/main/cpp/khaiii/nn/tensor.cpp
+++ b/src/main/cpp/khaiii/nn/tensor.cpp
@@ -28,7 +28,7 @@ using std::vector;
 float relu(float x) {
     return std::max(x, 0.0f);
 }
-activation_t RELU = std::ptr_fun(relu);    ///< ReLU function pointer
+activation_t RELU = &relu;    ///< ReLU function pointer
 
 
 ///////////////

--- a/src/main/cpp/khaiii/nn/tensor.hpp
+++ b/src/main/cpp/khaiii/nn/tensor.hpp
@@ -32,7 +32,7 @@ using vector_t = Eigen::VectorXf;
 //////////////////////////
 // activation functions //
 //////////////////////////
-typedef std::pointer_to_unary_function<float, float> activation_t;
+typedef std::function<float(float)> activation_t;
 extern activation_t RELU;
 
 


### PR DESCRIPTION
설명 (Description)
----
ISO C++17 표준에서 삭제된 std::pointer_to_unary_function, std::ptr_fun 사용을 std::function으로 변경합니다.

체크 리스트 (Checklist)
----
- [ ] master 브랜치가 아니라 **develop** 브랜치에 머지하도록 pull request를 작성 중이신가요? (Did you merge into **develop** branch not master?)
- [ ] `build/test/khaiii` 프로그램을 실행하여 **테스트**가 성공했나요? (Did all **tests** are passed when you ran as `build/test/khaiii`)
- [x] **PyLint** 툴을 실행하여 발생한 에러를 모두 수정하셨나요? (Did you fix all errors after running **PyLint**?)
- [x] **CppLint** 툴을 실행하여 발생한 에러를 모두 수정하셨나요? (Did you fix all errors after running **CppLint**?)

1. master와 develop이 분기된 상태로 어디에 랜딩을 하는게 맞을지 몰라, 일단 master로 보냅니다. develop브랜치에도 충돌 없이 머지 가능한것은 확인했습니다.
2. 패치 여부와 무관하게 테스트가 전량 패스하지 않습니다. 하기 로그 첨부합니다. 환경은 Apple clang version 12.0.0 (clang-1200.0.32.28), Target: arm64-apple-darwin20.2.0 입니다. (M1 맥북입니다.)

```
[==========] Running 13 tests from 4 test cases.
[----------] Global test environment set-up.
[----------] 1 test from ErrPatchTest
[ RUN      ] ErrPatchTest.apply
[2021-01-10 19:43:11.041] [ErrPatchTest] [warning] error not found: '지저스크라이스트' => E:'지저스크라이스/NNP + 트/NNG' vs A:'지저스/NNG + 크라이스트/NNP'
[2021-01-10 19:43:11.047] [ErrPatchTest] [warning] error not found: '지저스 크라이스트' => E:'지저스/NNP + _ + 크라이스/NNP + 트/NNG' vs A:'지저스/NNP + _ + 크라이스트/NNP'
[2021-01-10 19:43:11.058] [ErrPatchTest] [warning] error not found: '무함마드압둘라' => E:'무함마드압/NNP + 둘/NR + 라/NNP' vs A:'무함마드압둘라/NNP'
[       OK ] ErrPatchTest.apply (26 ms)
[----------] 1 test from ErrPatchTest (26 ms total)

[----------] 7 tests from KhaiiiApiTest
[ RUN      ] KhaiiiApiTest.version
[       OK ] KhaiiiApiTest.version (1 ms)
[ RUN      ] KhaiiiApiTest.open_close
[       OK ] KhaiiiApiTest.open_close (1 ms)
[ RUN      ] KhaiiiApiTest.analyze
[       OK ] KhaiiiApiTest.analyze (6 ms)
[ RUN      ] KhaiiiApiTest.free_results
[       OK ] KhaiiiApiTest.free_results (5 ms)
[ RUN      ] KhaiiiApiTest.last_error
[       OK ] KhaiiiApiTest.last_error (0 ms)
[ RUN      ] KhaiiiApiTest.restore_true
/Users/cynthia/Documents/checkouts/khaiii/src/test/cpp/khaiii/KhaiiiApiTest.cpp:65: Failure
Expected equality of these values:
  expected.c_str()
    Which is: "\xEB\xB3\xB4\xEC\x9D\xB4/VV + \xEC\x96\xB4/EC + \xEC\xA3\xBC/VX + \xE3\x84\xB9/ETM"
  oss.str().c_str()
    Which is: "\xEB\xB3\xB4\xEC\x9D\xB4/VV + \xEC\x96\xB4/EC + \xEC\xA4\x84/NNG"
[  FAILED  ] KhaiiiApiTest.restore_true (5 ms)
[ RUN      ] KhaiiiApiTest.restore_false
/Users/cynthia/Documents/checkouts/khaiii/src/test/cpp/khaiii/KhaiiiApiTest.cpp:65: Failure
Expected equality of these values:
  expected.c_str()
    Which is: "\xEB\xB3\xB4\xEC\x97\xAC/VV + \xEC\xA4\x84/VX"
  oss.str().c_str()
    Which is: "\xEB\xB3\xB4\xEC\x97\xAC/VV + \xEC\xA4\x84/NNG"
[  FAILED  ] KhaiiiApiTest.restore_false (3 ms)
[----------] 7 tests from KhaiiiApiTest (21 ms total)

[----------] 3 tests from KhaiiiDevTest
[ RUN      ] KhaiiiDevTest.analyze_bfr_errorpatch
[       OK ] KhaiiiDevTest.analyze_bfr_errorpatch (5 ms)
[ RUN      ] KhaiiiDevTest.set_log_level
[       OK ] KhaiiiDevTest.set_log_level (1 ms)
[ RUN      ] KhaiiiDevTest.set_log_levels
[       OK ] KhaiiiDevTest.set_log_levels (0 ms)
[----------] 3 tests from KhaiiiDevTest (6 ms total)

[----------] 2 tests from PreanalTest
[ RUN      ] PreanalTest.apply_exact
[       OK ] PreanalTest.apply_exact (0 ms)
[ RUN      ] PreanalTest.apply_prefix
[       OK ] PreanalTest.apply_prefix (0 ms)
[----------] 2 tests from PreanalTest (0 ms total)

[----------] Global test environment tear-down
[==========] 13 tests from 4 test cases ran. (53 ms total)
[  PASSED  ] 11 tests.
[  FAILED  ] 2 tests, listed below:
[  FAILED  ] KhaiiiApiTest.restore_true
[  FAILED  ] KhaiiiApiTest.restore_false
```